### PR TITLE
Added Release Action for full Docker release, removed release from PulserCI

### DIFF
--- a/.github/workflows/buildPulser.yml
+++ b/.github/workflows/buildPulser.yml
@@ -6,10 +6,8 @@ on:
       - 'pulser/*'
 
 jobs:
-  build:
-
+  buildFromMaven:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 12
@@ -27,18 +25,3 @@ jobs:
       uses: actions/docker/cli@master
       with:
         args: build -f ./pulser/BuildDockerfile ./pulser
-        
-  PublishToGithub:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: docker.pkg.github.com/twonki/microtope/pulser
-        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
-        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
-        chache: true
-        workdir: ./pulser
-        dockerfile: BuildDockerfile

--- a/.github/workflows/releaseAll.yml
+++ b/.github/workflows/releaseAll.yml
@@ -1,0 +1,82 @@
+name: publish docker packages
+
+on:
+  release:
+    types: [published]
+
+jobs: 
+
+  PublishPulserToGithub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Pulser and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/twonki/microtope/pulser
+        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        chache: true
+        workdir: ./pulser
+        dockerfile: BuildDockerfile
+
+  PublishWorkerToGithub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Worker and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/twonki/microtope/worker
+        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        chache: true
+        workdir: ./worker
+        dockerfile: BuildDockerfile
+
+  PublishDatabaseToGithub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Database and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/twonki/microtope/database
+        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        chache: true
+        workdir: ./database
+        dockerfile: Dockerfile
+
+  PublishUiToGithub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build UI and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/twonki/microtope/ui
+        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        chache: true
+        workdir: ./ui
+        dockerfile: Dockerfile
+
+  PublishAPIToGithub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build API and Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/twonki/microtope/database
+        username: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+        password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        chache: true
+        workdir: ./api
+        dockerfile: Dockerfile


### PR DESCRIPTION
Full Release action for every Docker package

**Reasons:**
- To fill packages
- To have every package remotely availible

**Changes:**

- New Action with all Docker-Publishes
- Runs on Release

**Possible Risks:**

None, Afaik

**Related Issues:**

To publishing #101 
