### PR TITLE
Passing test suite

### DIFF
--- a/ui/src/app/components/player-detail/player-detail.component.spec.ts
+++ b/ui/src/app/components/player-detail/player-detail.component.spec.ts
@@ -1,6 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
+import { AppConfigService } from '../../services/app-config.service';
 import { PlayerDetailComponent } from './player-detail.component';
+import { PlayerService } from '../../services/player.service';
 
 describe('PlayerDetailComponent', () => {
   let component: PlayerDetailComponent;
@@ -8,9 +10,19 @@ describe('PlayerDetailComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PlayerDetailComponent ]
-    })
-    .compileComponents();
+      declarations: [PlayerDetailComponent],
+
+      providers: [
+        {
+          provide: PlayerService,
+          useValue: jasmine.createSpyObj<PlayerService>(['getAll'])
+        },
+        {
+          provide: AppConfigService,
+          useValue: jasmine.createSpyObj<AppConfigService>(['loadAppConfig'])
+        }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/ui/src/app/components/player-splitscreen-page/player-splitscreen-page.component.spec.ts
+++ b/ui/src/app/components/player-splitscreen-page/player-splitscreen-page.component.spec.ts
@@ -1,5 +1,7 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
+import { AppConfigService } from '../../services/app-config.service';
+import { PlayerService } from '../../services/player.service';
 import { PlayerSplitscreenPageComponent } from './player-splitscreen-page.component';
 
 describe('PlayerSplitscreenPageComponent', () => {
@@ -8,9 +10,18 @@ describe('PlayerSplitscreenPageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PlayerSplitscreenPageComponent ]
-    })
-    .compileComponents();
+      declarations: [PlayerSplitscreenPageComponent],
+      providers: [
+        {
+          provide: PlayerService,
+          useValue: jasmine.createSpyObj<PlayerService>(['getAll'])
+        },
+        {
+          provide: AppConfigService,
+          useValue: jasmine.createSpyObj<AppConfigService>(['loadAppConfig'])
+        }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/ui/src/app/components/team-detail/team-detail.component.spec.ts
+++ b/ui/src/app/components/team-detail/team-detail.component.spec.ts
@@ -1,6 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
+import { AppConfigService } from 'src/app/services/app-config.service';
 import { TeamDetailComponent } from './team-detail.component';
+import { TeamService } from '../../services/team.service';
 
 describe('TeamDetailComponent', () => {
   let component: TeamDetailComponent;
@@ -8,9 +10,18 @@ describe('TeamDetailComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TeamDetailComponent ]
-    })
-    .compileComponents();
+      declarations: [TeamDetailComponent],
+      providers: [
+        {
+          provide: TeamService,
+          useValue: jasmine.createSpyObj<TeamService>(['getAll'])
+        },
+        {
+          provide: AppConfigService,
+          useValue: jasmine.createSpyObj<AppConfigService>(['loadAppConfig'])
+        }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/ui/src/app/components/team-splitscreen-page/team-splitscreen-page.component.spec.ts
+++ b/ui/src/app/components/team-splitscreen-page/team-splitscreen-page.component.spec.ts
@@ -1,21 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {TeamService} from '../../services/team.service';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
+import { TeamService } from '../../services/team.service';
 import { TeamSplitscreenPageComponent } from './team-splitscreen-page.component';
 
 describe('TeamSplitscreenPageComponent', () => {
   let component: TeamSplitscreenPageComponent;
   let fixture: ComponentFixture<TeamSplitscreenPageComponent>;
 
-  beforeAll(async(() => {
-    const spy = jasmine.createSpyObj('teamTeamService', 'getAll');
+  beforeEach(async(() => {
+    const spy = jasmine.createSpyObj('teamTeamService', ['getAll']);
     TestBed.configureTestingModule({
-      declarations: [ TeamSplitscreenPageComponent ],
-      providers: [
-        {provide: TeamService, useValue: spy}
-      ]
-    })
-    .compileComponents();
+      declarations: [TeamSplitscreenPageComponent],
+      providers: [{ provide: TeamService, useValue: spy }]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/ui/src/app/components/top-rankable/top-rankable.component.spec.ts
+++ b/ui/src/app/components/top-rankable/top-rankable.component.spec.ts
@@ -1,30 +1,34 @@
-import {TestBed} from '@angular/core/testing';
-import {of} from 'rxjs';
-import {SelectedService} from '../../services/selected.service';
-import {TopRankableComponent} from './top-rankable.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectedService } from '../../services/selected.service';
+import { TopRankableComponent } from './top-rankable.component';
+import { of } from 'rxjs';
 
 describe(`${TopRankableComponent.constructor.name}`, () => {
-  beforeAll(() => {
-    const spy = jasmine.createSpyObj('select', 'selected$');
+  let fixture: ComponentFixture<TopRankableComponent<any>>;
+  let component: TopRankableComponent<any>;
+
+  beforeEach(() => {
+    const spy = jasmine.createSpyObj('select', ['selected$']);
     TestBed.configureTestingModule({
       declarations: [TopRankableComponent],
-      providers: [
-        {provide: SelectedService, useValue: spy}
-      ]
-    });
+      providers: [{ provide: SelectedService, useValue: spy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TopRankableComponent);
+    component = fixture.componentInstance;
   });
 
-  it('should return empty Array if given empty Array', () => {
-
-    const fixture = TestBed.createComponent(TopRankableComponent);
-    const comp = fixture.componentInstance;
-
+  it('should return empty Array if given empty Array', done => {
     // Simulate "Input"
-    // comp.items = [];
+    component.items = of([]);
 
     // Trigger change detection, this is where ngOninit runs
     fixture.detectChanges();
 
-    expect(comp.sortedItems).toBe(of([]));
+    component.sortedItems.subscribe(items => {
+      expect(items).toEqual([]);
+      done();
+    });
   });
 });

--- a/ui/src/app/services/app-config.service.spec.ts
+++ b/ui/src/app/services/app-config.service.spec.ts
@@ -13,7 +13,7 @@ describe('AppConfigService', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       // Provide both the service-to-test and its (spy) dependency
-      providers: [AppConfigService, { provide: HttpClient, useValue: httpSpy }]
+      providers: [AppConfigService]
     });
     // Inject both the service-to-test and its (spy) dependency
     service = TestBed.get(AppConfigService);
@@ -21,7 +21,7 @@ describe('AppConfigService', () => {
   });
 
   it('should be created', () => {
-    const service: AppConfigService = TestBed.get(AppConfigService);
+    service = TestBed.get(AppConfigService);
     expect(service).toBeTruthy();
   });
 });

--- a/ui/src/app/services/app-config.service.spec.ts
+++ b/ui/src/app/services/app-config.service.spec.ts
@@ -1,34 +1,26 @@
-
 import { AppConfigService } from './app-config.service';
-import { HttpClientModule } from '@angular/common/http';
-
-import { TestBed } from '@angular/core/testing';
-import { HttpClient } from 'selenium-webdriver/http';
+import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
 
 describe('AppConfigService', () => {
+  let service: AppConfigService;
+  let httpClientSpy: jasmine.SpyObj<HttpClient>;
 
-let service: AppConfigService;
-let httpClientSpy: jasmine.SpyObj<HttpClient>;
+  beforeEach(() => {
+    const httpSpy = jasmine.createSpyObj('HttpClient', ['get', 'put', 'push']);
 
-beforeEach(() => {
-
-  const httpSpy = jasmine.createSpyObj('HttpClient', ['get', 'put', 'push']);
-
-  TestBed.configureTestingModule({
-    imports: [ HttpClientTestingModule ],
-    // Provide both the service-to-test and its (spy) dependency
-    providers: [
-      AppConfigService,
-      { provide: HttpClient, useValue: httpSpy}
-    ]
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      // Provide both the service-to-test and its (spy) dependency
+      providers: [AppConfigService, { provide: HttpClient, useValue: httpSpy }]
+    });
+    // Inject both the service-to-test and its (spy) dependency
+    service = TestBed.get(AppConfigService);
+    httpClientSpy = TestBed.get(HttpClient);
   });
-  // Inject both the service-to-test and its (spy) dependency
-  service = TestBed.get(AppConfigService);
-  httpClientSpy = TestBed.get(HttpClient);
-});
 
-it('should be created', () => {
+  it('should be created', () => {
     const service: AppConfigService = TestBed.get(AppConfigService);
     expect(service).toBeTruthy();
   });

--- a/ui/src/app/services/team.service.spec.ts
+++ b/ui/src/app/services/team.service.spec.ts
@@ -1,19 +1,20 @@
+import { AppConfigService } from './app-config.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TeamService } from './team.service';
 import { TestBed } from '@angular/core/testing';
 
-import { TeamService } from './team.service';
-
-import { HttpClient } from '@angular/common/http';
-import { AppConfigService } from './app-config.service';
-
 describe('TeamService', () => {
-
-  beforeAll(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [
-        {provide: HttpClient},
-        {provide: AppConfigService}
+        TeamService,
+        {
+          provide: AppConfigService,
+          useValue: jasmine.createSpyObj<AppConfigService>(['loadAppConfig'])
+        }
       ]
-    });
+    }).compileComponents();
   });
 
   it('should be created', () => {


### PR DESCRIPTION
**Short Summary of your changes**

**Reasons:**

Resolves #27 

**Changes:**

- Fixed an improper import (Selenium also exports an HttpClient, which is suuuuper annoying)
- Fixed broken test suites by adding imports, dependent services, etc

**Possible Risks:** 

Risk:  Now that the test suites pass, you have to write tests 😝 

**Related Issues:**

Writing custom mocks for commonly used services can be tedious.  Consider making a reusable MockAppConfigService (in `app-config.service.fake.ts`):

```typescript
@Injectable()
export class MockAppConfigService {
  loadAppConfig(): Observable<IConfig> {
    return of({ api_url: '/path/to' });
  }
}
```

Then, you can simply do the following in each service/component that needs it:

```typescript
providers: [{ provide: AppConfigService, useClass: MockAppConfigService }, ...]
```

Since you clearly have a grasp on interfaces, I'll also suggest using an interface that the real and mock services both implement.  It's a mechanism useful in keeping their function signatures in lock-step, future-proofing your tests.

```typescript
export interface IAppConfigService {
  loadAppConfig(): Observable<IConfig>
}

export class AppConfigService implements IAppConfigService...
export class MockAppConfigService implements IAppConfigService...
```
 
When you add a new function to the main service, add it to the interface (which I usually store in the same file as the main service).  That way, your tests using the mock crash until you also update the mock with a new mocked function.

**Additional Info:**

Good luck, and happy [Hacktoberfest](https://hacktoberfest.digitalocean.com/)!
